### PR TITLE
Add autoload magic comments for package initialization

### DIFF
--- a/find-things-fast.el
+++ b/find-things-fast.el
@@ -95,7 +95,7 @@
 ;; (global-set-key (kbd [f5]) 'ftf-compile)
 
 ;;; Code:
-
+;;;###autoload
 (defvar ftf-filetypes
   '("*.h" "*.hpp" "*.cpp" "*.c" "*.cc" "*.cpp" "*.inl" "*.grd" "*.idl" "*.m"
     "*.mm" "*.py" "*.sh" "*.cfg" "*SConscript" "SConscript*" "*.scons"
@@ -103,6 +103,7 @@
   "A list of filetype patterns that grepsource will use. Obviously biased for
 chrome development.")
 
+;;;###autoload
 (defun ftf-add-filetypes (types)
   "Makes `ftf-filetypes' local to this buffer and adds the
 elements of list types to the list"
@@ -194,6 +195,7 @@ otherwise defaulting to `find-tag-default'."
         (or default (error "There is no default symbol to grep for."))
       spec))))
 
+;;;###autoload
 (defun ftf-grepsource (cmd-args)
   "Greps the current project, leveraging local repository data
 for speed and falling back on a big \"find | xargs grep\"
@@ -272,6 +274,7 @@ the file name."
 	  (concat (car file-cons) ": "
 		  (cadr (reverse (split-string (cdr file-cons) "/"))))))
 
+;;;###autoload
 (defun ftf-find-file ()
   "Prompt with a completing list of all files in the project to find one.
 
@@ -299,11 +302,13 @@ custom functions which might want to run "
   `(let ((default-directory (ftf-project-directory)))
           ,@body))
 
+;;;###autoload
 (defun ftf-compile ()
   "Run the `compile' function from the project root."
   (interactive)
   (with-ftf-project-root (call-interactively 'compile)))
 
+;;;###autoload
 (defun ftf-gdb ()
   "Run the `gdb' function from the project root."
   (interactive)


### PR DESCRIPTION
Add autoload magic comments, so that documented functions are available
when the source is loaded as a package, say from MELPA.

.. I don't know much about elisp, though.. 
