### PR TITLE
Change ftf-add-filetype example to include ARGS for the mode hook.

### DIFF
--- a/find-things-fast.el
+++ b/find-things-fast.el
@@ -79,7 +79,7 @@
 ;; use in your mode hook, `ftf-add-filetypes'. Example:
 ;;
 ;; (add-hook 'emacs-lisp-mode-hook
-;;           (lambda (ftf-add-filetypes '("*.el" "*.elisp"))))
+;;           (lambda () (ftf-add-filetypes '("*.el" "*.elisp"))))
 
 ;; If `ido-mode' is enabled, the menu will use `ido-completing-read'
 ;; instead of `completing-read'.


### PR DESCRIPTION
I am new to emacs (after 20 years of vim), and I stumbled on this when first using ftf. 
Copy and paste of that example does not work without the additional ARGS.