### PR TITLE
Use null-device instead of grep-use-null-device (which didn't work)

### DIFF
--- a/find-things-fast.el
+++ b/find-things-fast.el
@@ -246,14 +246,10 @@ directory if none of the above is found."
   (interactive (ftf-interactive-default-read "Grep project for string: "))
   ;; When we're in a git repository, use git grep so we don't have to
   ;; find-files.
-  ;;
-  ;; TODO(erg): The `grep-use-null-device' below doesn't actually work;
-  ;; grep-mode does some weird stuff and we have to call a
-  ;; `grep-apply-setting'?
   (let ((quoted (replace-regexp-in-string "\"" "\\\\\"" cmd-args))
         (git-toplevel (ftf-get-top-git-dir default-directory))
         (default-directory (ftf-project-directory))
-        (grep-use-null-device nil))
+        (null-device nil))
     (cond (git-toplevel ;; We can accelerate our grep using the git data.
            (grep (concat "git --no-pager grep --no-color -n -e \""
                          quoted


### PR DESCRIPTION
Basically, null-device defaults to "/dev/null", but if it is set to nil it is not used at all (which is what we want).