### PR TITLE
Check ido-mode in addition to ido-completing-read

### DIFF
--- a/find-things-fast.el
+++ b/find-things-fast.el
@@ -322,7 +322,9 @@ defined by the optional `project-root.el' package OR the default
 directory if none of the above is found."
   (interactive)
   (let* ((project-files (ftf-project-files-alist))
-	 (filename (if (and ido-mode (functionp 'ido-completing-read))
+	 (filename (if (and (boundp 'ido-mode)
+			    ido-mode
+			    (functionp 'ido-completing-read))
                    (ido-completing-read "Find file in project: "
                                         (mapcar 'car project-files))
                  (completing-read "Find file in project: "

--- a/find-things-fast.el
+++ b/find-things-fast.el
@@ -322,7 +322,7 @@ defined by the optional `project-root.el' package OR the default
 directory if none of the above is found."
   (interactive)
   (let* ((project-files (ftf-project-files-alist))
-	 (filename (if (functionp 'ido-completing-read)
+	 (filename (if (and ido-mode (functionp 'ido-completing-read))
                    (ido-completing-read "Find file in project: "
                                         (mapcar 'car project-files))
                  (completing-read "Find file in project: "


### PR DESCRIPTION
ido-completing-read can exist even when ido-mode is turned off (especially since it's now
included in Emacs 24 by default). So check ido-mode also.
